### PR TITLE
Control record changes for better spec matching

### DIFF
--- a/FileFormatTypes/BankOfTheWest.cs
+++ b/FileFormatTypes/BankOfTheWest.cs
@@ -44,7 +44,7 @@ Amount: {{ Amount }}", order: 20 )]
                 PayorRoutingNumber = "500100015",
                 CreditAccountNumber = accountNumber,
                 Amount = transactions.Sum( t => t.TotalAmount ),
-                InstitutionItemSequenceNumber = string.Format( "{0}{1}", RockDateTime.Now.ToString( "yyMMddHHmmss" ), bundleIndex ),
+                InstitutionItemSequenceNumber = string.Format( "{0}{1}", RockDateTime.Now.ToString( "yyMMddHHmmss" ), bundleIndex.ToString( "D3" ) ),
                 DebitCreditIndicator = "2"
             };
             records.Add( creditDetail );


### PR DESCRIPTION
A couple changes that were seen in the validation results of our test with BoTW (though in re-reading the various bank spec sheets these changes seem to be correct for all banks. If that is not so then we can revert some of these changes and move them into the BankOfTheWest subclass).

Also, changed how we search for pre-existing records. This should better support subclassing record types as well as support for a "non-standard" record types for specific banks (example if Bank C makes use of the Reserved field space and a custom record type is needed that cannot be a subclass of the existing standard record).

Currently, when dealing with the CheckDetail records we cast to `dynamic` and access the `ItemAmount` property, hoping it exists and is defined as a decimal. We might want to look at a few of these records and the "bare minimum, required fields" and create interfaces out of them. This would only be needed if a custom record cannot be a subclass of the CheckDetail record type so we'll leave it for later.