### PR TITLE
Couple fixes related to File Id and Cash Letter Id

### DIFF
--- a/FileFormatTypes/BankOfTheWest.cs
+++ b/FileFormatTypes/BankOfTheWest.cs
@@ -10,6 +10,8 @@ using Rock.Attribute;
 using Rock.Model;
 
 using com.shepherdchurch.ImageCashLetter.Model;
+using X937.Records;
+using System.Text;
 
 namespace com.shepherdchurch.ImageCashLetter.FileFormatTypes
 {
@@ -25,6 +27,87 @@ Account: {{ FileFormat | Attribute:'AccountNumber' }}
 Amount: {{ Amount }}", order: 20 )]
     public class BankOfTheWest : X937DSTU
     {
+        #region System Setting Keys
+
+        /// <summary>
+        /// The system setting for the next cash header identifier. These should never be
+        /// repeated. Ever.
+        /// </summary>
+        protected const string SystemSettingNextCashHeaderId = "com.shepherdchurch.ImageCashLetter.BankOfTheWest.NextCashHeaderId";
+
+        /// <summary>
+        /// The system setting that contains the last file modifier we used.
+        /// </summary>
+        protected const string SystemSettingLastFileModifier = "com.shepherdchurch.ImageCashLetter.BankOfTheWest.LastFileModifier";
+
+        #endregion
+
+        /// <summary>
+        /// Gets the file header record (type 01).
+        /// </summary>
+        /// <param name="fileFormat">The file format that contains the configuration to use.</param>
+        /// <returns>
+        /// A FileHeader record.
+        /// </returns>
+        protected override FileHeader GetFileHeaderRecord( ImageCashLetterFileFormat fileFormat )
+        {
+            var header = base.GetFileHeaderRecord( fileFormat );
+
+            //
+            // The combination of the following fields must be unique:
+            // DestinationRoutingNumber + OriginatingRoutingNumber + CreationDateTime + FileIdModifier
+            //
+            // If the last file we sent has the same routing numbers and creation date time then
+            // increment the file id modifier.
+            //
+            var fileIdModifier = "A";
+            var hashText = header.ImmediateDestinationRoutingNumber + header.ImmediateOriginRoutingNumber + header.FileCreationDateTime.ToString( "yyyyMMddHHmm" );
+            var hash = HashString( hashText );
+
+            //
+            // find the last modifier, if there was one.
+            //
+            var lastModifier = Rock.Web.SystemSettings.GetValue( SystemSettingLastFileModifier );
+            if ( !string.IsNullOrWhiteSpace( lastModifier ) )
+            {
+                var components = lastModifier.Split( '|' );
+
+                if ( components.Length == 2 )
+                {
+                    //
+                    // If the modifier is for the same file, increment the file modifier.
+                    //
+                    if ( components[0] == hash )
+                    {
+                        fileIdModifier = ( ( char ) ( components[1][0] + 1 ) ).ToString();
+                    }
+                }
+            }
+
+            header.FileIdModifier = fileIdModifier;
+            Rock.Web.SystemSettings.SetValue( SystemSettingLastFileModifier, string.Join( "|", hash, fileIdModifier ) );
+
+            return header;
+        }
+
+        /// <summary>
+        /// Gets the cash letter header record (type 10).
+        /// </summary>
+        /// <param name="fileFormat">The file format that contains the configuration to use.</param>
+        /// <returns>
+        /// A CashLetterHeader record.
+        /// </returns>
+        protected override CashLetterHeader GetCashLetterHeaderRecord( ImageCashLetterFileFormat fileFormat )
+        {
+            int cashHeaderId = Rock.Web.SystemSettings.GetValue( SystemSettingNextCashHeaderId ).AsIntegerOrNull() ?? 0;
+
+            var header = base.GetCashLetterHeaderRecord( fileFormat );
+            header.ID = cashHeaderId.ToString( "D8" );
+            Rock.Web.SystemSettings.SetValue( SystemSettingNextCashHeaderId, ( cashHeaderId + 1 ).ToString() );
+
+            return header;
+        }
+
         /// <summary>
         /// Gets the credit detail deposit record (type 61).
         /// </summary>
@@ -39,7 +122,7 @@ Amount: {{ Amount }}", order: 20 )]
 
             var records = new List<X937.Record>();
 
-            var creditDetail = new X937.Records.CreditDetail
+            var creditDetail = new CreditDetail
             {
                 PayorRoutingNumber = "500100015",
                 CreditAccountNumber = accountNumber,
@@ -56,7 +139,7 @@ Amount: {{ Amount }}", order: 20 )]
                     //
                     // Get the Image View Detail record (type 50).
                     //
-                    var detail = new X937.Records.ImageViewDetail
+                    var detail = new ImageViewDetail
                     {
                         ImageIndicator = 1,
                         ImageCreatorRoutingNumber = routingNumber,
@@ -71,7 +154,7 @@ Amount: {{ Amount }}", order: 20 )]
                     //
                     // Get the Image View Data record (type 52).
                     //
-                    var data = new X937.Records.ImageViewData
+                    var data = new ImageViewData
                     {
                         InstitutionRoutingNumber = routingNumber,
                         BundleBusinessDate = DateTime.Now,
@@ -95,7 +178,7 @@ Amount: {{ Amount }}", order: 20 )]
         /// <param name="transactions">The transactions associated with this deposit.</param>
         /// <param name="isFrontSide">True if the image to be retrieved is the front image.</param>
         /// <returns>A stream that contains the image data in TIFF 6.0 CCITT Group 4 format.</returns>
-        protected virtual Stream GetDepositSlipImage( ImageCashLetterFileFormat fileFormat, X937.Records.CreditDetail creditDetail, bool isFrontSide )
+        protected virtual Stream GetDepositSlipImage( ImageCashLetterFileFormat fileFormat, CreditDetail creditDetail, bool isFrontSide )
         {
             var bitmap = new System.Drawing.Bitmap( 1200, 550 );
             var g = System.Drawing.Graphics.FromImage( bitmap );
@@ -142,6 +225,20 @@ Amount: {{ Amount }}", order: 20 )]
             ms.Position = 0;
 
             return ms;
+        }
+
+        /// <summary>
+        /// Hashes the string with SHA256.
+        /// </summary>
+        /// <param name="contents">The contents to be hashed.</param>
+        /// <returns>A hex representation of the hash.</returns>
+        protected string HashString( string contents )
+        {
+            byte[] byteContents = Encoding.Unicode.GetBytes( contents );
+
+            var hash = new System.Security.Cryptography.SHA256CryptoServiceProvider().ComputeHash( byteContents );
+
+            return string.Join( "", hash.Select( b => b.ToString( "x2" ) ).ToArray() );
         }
     }
 }

--- a/FileFormatTypes/X937DSTU.cs
+++ b/FileFormatTypes/X937DSTU.cs
@@ -111,6 +111,7 @@ namespace com.shepherdchurch.ImageCashLetter.FileFormatTypes
         {
             var destinationRoutingNumber = Rock.Security.Encryption.DecryptString( GetAttributeValue( fileFormat, "RoutingNumber" ) );
             var originRoutingNumber = Rock.Security.Encryption.DecryptString( GetAttributeValue( fileFormat, "AccountNumber" ) );
+
             var header = new X937.Records.FileHeader
             {
                 StandardLevel = 3,
@@ -178,7 +179,6 @@ namespace com.shepherdchurch.ImageCashLetter.FileFormatTypes
                 CreationDateTime = DateTime.Now,
                 RecordTypeIndicator = "I",
                 DocumentationTypeIndicator = "G",
-                ID = "TODO", // TODO: Fix this, waiting for feedback from bank.
                 OriginatorContactName = contactName,
                 OriginatorContactPhoneNumber = contactPhone
             };


### PR DESCRIPTION
Most (hopefully) banks don't seem to use these fields, so moved the (new) logic into the Bank of The West component.

Stores the Id numbers as System Settings so on subsequent runs we can determine if we need new Ids or can re-use the old ones.